### PR TITLE
Kinesis Data Firehoseと連携し、ログの永続化を構築

### DIFF
--- a/terraform/cloud_watch.tf
+++ b/terraform/cloud_watch.tf
@@ -39,6 +39,15 @@ resource "aws_cloudwatch_event_target" "example_batch" {
 
 # オペレーションログを保存するCloudWatch Logsの定義
 resource "aws_cloudwatch_log_group" "operation" {
-  name = "/operation"
+  name              = "/operation"
   retention_in_days = 180
+}
+
+# CloudWatchLogsサブスクリプションフィルタを作成
+resource "aws_cloudwatch_log_subscription_filter" "example" {
+  name            = "example"
+  log_group_name  = aws_cloudwatch_log_group.for_ecs_scheduled_tasks.name
+  destination_arn = aws_kinesis_firehose_delivery_stream.example.arn
+  filter_pattern  = "[]"
+  role_arn        = module.cloudwatch_logs_role.iam_role_arn
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -149,3 +149,11 @@ data "aws_iam_policy_document" "cloudwatch_logs" {
     resources = ["arn:aws:iam::*:role/cloudwatch-logs"]
   }
 }
+
+# CloudWatch Logs IAMロールの定義
+module "cloudwatch_logs_role" {
+  source     = "./modules/iam_role"
+  name       = "cloudwatch-logs"
+  identifier = "logs.ap-northeast-1.amazonaws.com"
+  policy     = data.aws_iam_policy_document.cloudwatch_logs.json
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -134,3 +134,18 @@ module "kinesis_data_firehose_role" {
   identifier = "firehose.amazonaws.com"
   policy     = data.aws_iam_policy_document.kinesis_data_firehose.json
 }
+
+# CloudWatch Logs IAMロールのポリシードキュメントの定義
+data "aws_iam_policy_document" "cloudwatch_logs" {
+  statement {
+    effect    = "Allow"
+    actions   = ["firehose:*"]
+    resources = ["arn:aws:firehose:ap-northeast-1:*:*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::*:role/cloudwatch-logs"]
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -105,3 +105,24 @@ resource "aws_iam_instance_profile" "ec2_for_ssm" {
   name = "ec2-for-ssm"
   role = module.ec2_for_ssm_role.iam_role_name
 }
+
+# Kinesis Data Firehose用の操作権限
+data "aws_iam_policy_document" "kinesis_data_firehose" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.cloudwatch_logs.id}",
+      "arn:aws:s3:::${aws_s3_bucket.cloudwatch_logs.id}/*",
+    ]
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -126,3 +126,11 @@ data "aws_iam_policy_document" "kinesis_data_firehose" {
     ]
   }
 }
+
+# Kinesis Data Firehose IAMロールの定義
+module "kinesis_data_firehose_role" {
+  source     = "./modules/iam_role"
+  name       = "kinesis-data-firehose"
+  identifier = "firehose.amazonaws.com"
+  policy     = data.aws_iam_policy_document.kinesis_data_firehose.json
+}

--- a/terraform/kinesis_data_firehose.tf
+++ b/terraform/kinesis_data_firehose.tf
@@ -1,0 +1,11 @@
+# KinesisDataFirehoseのデータストリームをS3へ
+resource "aws_kinesis_firehose_delivery_stream" "example" {
+  name        = "example"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn   = module.kinesis_data_firehose_role.iam_role_arn
+    bucket_arn = aws_s3_bucket.cloudwatch_logs.arn
+    prefix     = "ecs-scheduled-tasks/example/"
+  }
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -93,7 +93,7 @@ resource "aws_s3_bucket" "operation" {
 }
 
 # CloudWatch Logs永続化バケットの定義
-esource "aws_s3_bucket" "cloudwatch_logs" {
+resource "aws_s3_bucket" "cloudwatch_logs" {
   bucket = "chinkibucket-cloudwatch-logs-pragmatic-terraform"
 
   lifecycle_rule {

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -91,3 +91,18 @@ resource "aws_s3_bucket" "operation" {
   # 削除保護設定
   force_destroy = true
 }
+
+# CloudWatch Logs永続化バケットの定義
+esource "aws_s3_bucket" "cloudwatch_logs" {
+  bucket = "chinkibucket-cloudwatch-logs-pragmatic-terraform"
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = "180"
+    }
+  }
+  # 削除保護設定
+  force_destroy = true
+}


### PR DESCRIPTION
## What
CloudWatch LogsのデータをS3に保存するようにしました
## Why
CloudWatch Logsのストレージは割高なので